### PR TITLE
ci: auto-update gomod2nix.toml in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,10 +202,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, darwin, windows]
-        goarch: [amd64, arm64]
-        exclude:
-          - goos: windows
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
             goarch: arm64
     steps:
       - name: Checkout code
@@ -220,11 +224,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: |
           mkdir -p dist
-          EXT=""
-          if [ "$GOOS" = "windows" ]; then
-            EXT=".exe"
-          fi
-          go build -o dist/better-fg-${{ matrix.goos }}-${{ matrix.goarch }}${EXT} ./cmd/better-fg
+          go build -o dist/better-fg-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/better-fg
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,14 @@ jobs:
   check-gomod2nix:
     name: Check gomod2nix.toml
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Restore and save Nix store
@@ -26,8 +31,29 @@ jobs:
           purge-created: 0
           purge-last-accessed: 0
           purge-primary-key: never
-      - name: Check gomod2nix.toml is up to date
-        run: nix develop --command ./scripts/check-gomod2nix.sh
+      - name: Install direnv
+        run: |
+          curl -sfL https://direnv.net/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Allow direnv
+        run: direnv allow
+      - name: Check and update gomod2nix.toml
+        run: |
+          # Generate fresh gomod2nix.toml
+          direnv exec . gomod2nix generate
+          
+          # Check if there are changes
+          if git diff --quiet gomod2nix.toml; then
+            echo "✅ gomod2nix.toml is up to date!"
+          else
+            echo "📝 gomod2nix.toml was updated"
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add gomod2nix.toml
+            git commit -m "chore: update gomod2nix.toml"
+            git push
+            echo "✅ gomod2nix.toml has been updated and committed"
+          fi
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,36 +197,88 @@ jobs:
             git diff flake.lock
             exit 1
           fi
-  build-cross-platform:
-    name: Build Cross Platform
+  build-linux-x86_64:
+    name: Build Linux x86_64
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - name: Build binary
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-        run: |
-          mkdir -p dist
-          go build -o dist/better-fg-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/better-fg
-      - name: Upload artifacts
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', '**/go.sum', '**/gomod2nix.toml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never
+      - name: Build with Nix
+        run: nix build .#packages.x86_64-linux.default
+      - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: better-fg-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/
+          name: better-fg-x86_64-linux
+          path: result/bin/better-fg
+
+  build-linux-aarch64:
+    name: Build Linux aarch64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', '**/go.sum', '**/gomod2nix.toml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never
+      - name: Build aarch64 binary with Go cross-compilation
+        run: |
+          mkdir -p dist
+          nix develop --command bash -c 'GOOS=linux GOARCH=arm64 go build -o dist/better-fg-aarch64-linux ./cmd/better-fg'
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: better-fg-aarch64-linux
+          path: dist/better-fg-aarch64-linux
+
+  build-darwin:
+    name: Build Darwin
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock', '**/go.sum', '**/gomod2nix.toml') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never
+      - name: Build with Nix
+        run: nix build .#packages.${{ matrix.arch }}-darwin.default
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: better-fg-${{ matrix.arch }}-darwin
+          path: result/bin/better-fg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Build aarch64 binary with Go cross-compilation
         run: |
           mkdir -p dist
-          nix develop --command bash -c 'GOOS=linux GOARCH=arm64 go build -o dist/better-fg-aarch64-linux ./cmd/better-fg'
+          nix develop --command bash -c 'CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o dist/better-fg-aarch64-linux ./cmd/better-fg'
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build for aarch64-linux with Go cross-compilation
         run: |
           mkdir -p dist
-          nix develop --command bash -c 'GOOS=linux GOARCH=arm64 go build -o dist/better-fg-aarch64-linux ./cmd/better-fg'
+          nix develop --command bash -c 'CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o dist/better-fg-aarch64-linux ./cmd/better-fg'
       - uses: actions/upload-artifact@v7
         with:
           name: better-fg-aarch64-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,19 +8,22 @@ permissions:
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31.10.4
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build for x86_64-linux
+      - name: Build for ${{ matrix.arch }}-linux
         run: |
-          nix build .#packages.x86_64-linux.default
+          nix build .#packages.${{ matrix.arch }}-linux.default
           mkdir -p dist
-          cp result/bin/better-fg dist/better-fg-x86_64-linux
+          cp result/bin/better-fg dist/better-fg-${{ matrix.arch }}-linux
       - uses: actions/upload-artifact@v7
         with:
-          name: better-fg-x86_64-linux
+          name: better-fg-${{ matrix.arch }}-linux
           path: dist/
   build-darwin:
     runs-on: macos-latest
@@ -59,6 +62,7 @@ jobs:
               system=${basename#better-fg-}
               case $system in
                 x86_64-linux) archive="better-fg_Linux_x86_64.tar.gz" ;;
+                aarch64-linux) archive="better-fg_Linux_arm64.tar.gz" ;;
                 x86_64-darwin) archive="better-fg_Darwin_x86_64.tar.gz" ;;
                 aarch64-darwin) archive="better-fg_Darwin_arm64.tar.gz" ;;
               esac
@@ -100,10 +104,12 @@ jobs:
           curl -L -o darwin_x86_64.tar.gz "https://github.com/super-smooth/better-fg/releases/download/v${VERSION}/better-fg_Darwin_x86_64.tar.gz"
           curl -L -o darwin_arm64.tar.gz "https://github.com/super-smooth/better-fg/releases/download/v${VERSION}/better-fg_Darwin_arm64.tar.gz"
           curl -L -o linux_x86_64.tar.gz "https://github.com/super-smooth/better-fg/releases/download/v${VERSION}/better-fg_Linux_x86_64.tar.gz"
+          curl -L -o linux_arm64.tar.gz "https://github.com/super-smooth/better-fg/releases/download/v${VERSION}/better-fg_Linux_arm64.tar.gz"
           # Calculate SHA256 hashes
           DARWIN_X86_64_SHA=$(sha256sum darwin_x86_64.tar.gz | cut -d' ' -f1)
           DARWIN_ARM64_SHA=$(sha256sum darwin_arm64.tar.gz | cut -d' ' -f1)
           LINUX_X86_64_SHA=$(sha256sum linux_x86_64.tar.gz | cut -d' ' -f1)
+          LINUX_ARM64_SHA=$(sha256sum linux_arm64.tar.gz | cut -d' ' -f1)
           # Update the formula with new version and hashes
           sed -i "s|download/v[^/]*/|download/v${VERSION}/|g" Formula/better-fg.rb
           
@@ -112,6 +118,7 @@ jobs:
           sed -i '/Darwin_arm64\.tar\.gz/,/sha256/ s/sha256.*/sha256 "'"${DARWIN_ARM64_SHA}"'"/' Formula/better-fg.rb
           sed -i '/Darwin_x86_64\.tar\.gz/,/sha256/ s/sha256.*/sha256 "'"${DARWIN_X86_64_SHA}"'"/' Formula/better-fg.rb
           sed -i '/Linux_x86_64\.tar\.gz/,/sha256/ s/sha256.*/sha256 "'"${LINUX_X86_64_SHA}"'"/' Formula/better-fg.rb
+          sed -i '/Linux_arm64\.tar\.gz/,/sha256/ s/sha256.*/sha256 "'"${LINUX_ARM64_SHA}"'"/' Formula/better-fg.rb
           # Commit and push changes
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,24 +6,37 @@ on:
 permissions:
   contents: write
 jobs:
-  build-linux:
+  build-linux-x86_64:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31.10.4
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build for ${{ matrix.arch }}-linux
+      - name: Build for x86_64-linux
         run: |
-          nix build .#packages.${{ matrix.arch }}-linux.default
+          nix build .#packages.x86_64-linux.default
           mkdir -p dist
-          cp result/bin/better-fg dist/better-fg-${{ matrix.arch }}-linux
+          cp result/bin/better-fg dist/better-fg-x86_64-linux
       - uses: actions/upload-artifact@v7
         with:
-          name: better-fg-${{ matrix.arch }}-linux
+          name: better-fg-x86_64-linux
+          path: dist/
+
+  build-linux-aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31.10.4
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build for aarch64-linux with Go cross-compilation
+        run: |
+          mkdir -p dist
+          nix develop --command bash -c 'GOOS=linux GOARCH=arm64 go build -o dist/better-fg-aarch64-linux ./cmd/better-fg'
+      - uses: actions/upload-artifact@v7
+        with:
+          name: better-fg-aarch64-linux
           path: dist/
   build-darwin:
     runs-on: macos-latest
@@ -45,7 +58,7 @@ jobs:
           name: better-fg-${{ matrix.arch }}-darwin
           path: dist/
   release:
-    needs: [build-linux, build-darwin]
+    needs: [build-linux-x86_64, build-linux-aarch64, build-darwin]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Modify check-gomod2nix job to automatically regenerate and commit gomod2nix.toml when it's out of date. This handles Dependabot PRs that update go.mod/go.sum but can't run lefthook.