### PR TITLE
fix: capture gofmt output once to avoid race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,10 @@ jobs:
         run: nix develop --command golangci-lint run --timeout=5m
       - name: Check formatting
         run: |
-          if [ "$(nix develop --command gofmt -s -l . | wc -l)" -gt 0 ]; then
+          OUTPUT=$(nix develop --command gofumpt -l .)
+          if [ -n "$OUTPUT" ]; then
             echo "The following files are not formatted:"
-            nix develop --command gofmt -s -l .
+            echo "$OUTPUT"
             exit 1
           fi
       - name: Go vet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
           purge-last-accessed: 0
           purge-primary-key: never
 
+      - name: Setup dev environment
+        if: steps.check.outputs.needs-gomod2nix-check == 'true'
+        run: nix develop --command true
+
       - name: Check if gomod2nix.toml needs regeneration
         id: gomod2nix-check
         if: steps.check.outputs.needs-gomod2nix-check == 'true'
@@ -158,6 +162,8 @@ jobs:
           purge-last-accessed: 0
           # except any version with the key that is the same as the `primary-key`
           purge-primary-key: never
+      - name: Setup dev environment
+        run: nix develop --command true
       - name: Download dependencies
         run: nix develop --command go mod download
       - name: Run unit tests
@@ -200,6 +206,8 @@ jobs:
           purge-last-accessed: 0
           # except any version with the key that is the same as the `primary-key`
           purge-primary-key: never
+      - name: Setup dev environment
+        run: nix develop --command true
       - name: golangci-lint
         run: nix develop --command golangci-lint run --timeout=5m
       - name: Check formatting

--- a/.github/workflows/gomod2nix.yml
+++ b/.github/workflows/gomod2nix.yml
@@ -55,6 +55,10 @@ jobs:
           purge-last-accessed: 0
           purge-primary-key: never
 
+      - name: Setup dev environment
+        if: steps.check-go-mod.outputs.go-mod-changed == 'true'
+        run: nix develop --command true
+
       - name: Import GPG key
         if: steps.check-go-mod.outputs.go-mod-changed == 'true'
         id: import-gpg

--- a/flake.nix
+++ b/flake.nix
@@ -52,8 +52,8 @@
           shellHook = ''
             export CGO_ENABLED="1"
 
-            # Auto-install lefthook if in a git repo and lefthook.yml exists
-            if [ -d .git ] && [ -f lefthook.yml ]; then
+            # Auto-install lefthook if in a git repo and lefthook.yml exists (skip in CI)
+            if [ -z "$CI" ] && [ -d .git ] && [ -f lefthook.yml ]; then
               if ! lefthook version &> /dev/null; then
                 echo "⚠️  lefthook not found in PATH"
               elif [ ! -f .git/hooks/lefthook ] && [ ! -f .git/hooks/pre-commit ]; then


### PR DESCRIPTION
Previously we ran 'nix develop --command gofmt' twice - once piped to wc -l

and once to print files. This could cause inconsistent results.

Now we capture the output once and reuse it, ensuring consistent

behavior when checking formatting.